### PR TITLE
Small improvements for mouseclicker

### DIFF
--- a/mouseclicker/mouseclicker.py
+++ b/mouseclicker/mouseclicker.py
@@ -9,6 +9,7 @@ Last edited: January 2018
 """
 
 import sys, os, time
+import signal
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (QApplication, QComboBox, QGridLayout, 
     QLabel, QLineEdit, QMessageBox, QWidget)
@@ -125,5 +126,7 @@ class MouseClicker(QWidget):
 if __name__ == '__main__':
 
     app = QApplication(sys.argv)
+    # If the app is sent a Ctrl-C, just die.  There is no state to save
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
     ex = MouseClicker()
     sys.exit(app.exec_())

--- a/mouseclicker/mouseclicker.py
+++ b/mouseclicker/mouseclicker.py
@@ -92,11 +92,11 @@ class MouseClicker(QWidget):
 
             # os.popen("xdotool click --delay 90 --repeat 1000 1")
             while(self.counter <= self.countEnd):
-                os.popen("xdotool click 1")
-                print("the counter is: " + str(self.counter))
                 if(cursorOldPos != str(QCursor().pos())):
                     print("Mouse moved - loop terminated")
                     break
+                os.popen("xdotool click 1")
+                print("the counter is: " + str(self.counter))
                 self.counter += 1
                 # sets delay between clicks
                 time.sleep(float(self.clkDelay.text()))


### PR DESCRIPTION
# Description
This pullrequest is for two changes.

First, it causes a Ctrl-C on the command-line to kill the mouseclicker app.

Second, it causes the mouse-clicker app to check if the mouse has moved before the click, and not after.  In my case, I was using a delay of 5 seconds, so 5 seconds was passing between the movement check and the click, causing clicks on other parts of the screen.
